### PR TITLE
Make yarn start to build the project before starting it

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,5 +3,5 @@ This project parses the BNT (Bulgarian National Television)'s archive and genera
 
 # Development
 ```
-yarn build && yarn start -si <show_id>
+yarn start -si <show_id>
 ```

--- a/package.json
+++ b/package.json
@@ -3,7 +3,7 @@
   "version": "1.0.0",
   "main": "src/start.js",
   "scripts": {
-    "start": "node build/start.js",
+    "start": "yarn build && node build/start.js",
     "build": "babel src -d build"
   },
   "license": "GPL-2.0-or-later",


### PR DESCRIPTION
This PR makes `yarn start` build the project before starting. This way only one command is needed to run it.